### PR TITLE
hooks/91-grub-mkconfig: don't try generating config if nonexistent

### DIFF
--- a/hooks/91-grub-mkconfig.install
+++ b/hooks/91-grub-mkconfig.install
@@ -11,15 +11,15 @@ die() {
 }
 
 einfo() {
-    echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
+	echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
 }
 
 ewarn() {
-    echo -e " ${NOCOLOR-\e[1;33m*\e[0m }${*}" >&2
+	echo -e " ${NOCOLOR-\e[1;33m*\e[0m }${*}" >&2
 }
 
 eerror() {
-    echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
+	echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
 }
 
 main() {

--- a/hooks/91-grub-mkconfig.install
+++ b/hooks/91-grub-mkconfig.install
@@ -11,7 +11,15 @@ die() {
 }
 
 einfo() {
-        echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
+    echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
+}
+
+ewarn() {
+    echo -e " ${NOCOLOR-\e[1;33m*\e[0m }${*}" >&2
+}
+
+eerror() {
+    echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
 }
 
 main() {
@@ -19,19 +27,19 @@ main() {
 	[[ -n ${NOCOLOR+yes} ]] && NOCOLOR=
 
 	# do nothing if somehow GRUB is not installed
-	[[ -x $(command -v grub-mkconfig) ]] || exit 0
+	[[ -x $(command -v grub-mkconfig) ]] || { ewarn "grub-mkconfig command not available" && exit 0 ; }
 
 	[[ ${EUID} -eq 0 ]] || die "Please run this script as root"
 
 	if [[ -f ${GRUB_CFG} ]]; then
-		einfo "Backing up existing GRUB config as ${GRUB_CFG}~"
-		cp -v "${GRUB_CFG}"{,~} || die "Failed to save existing config"
+        einfo "Backing up existing grub config as ${GRUB_CFG}~"
+        cp -v "${GRUB_CFG}"{,~} || die "Failed to save existing config"
 	fi
 
 	einfo "Generating new GRUB config as ${GRUB_CFG}"
 	local dname="${GRUB_CFG%/*}"
 	mkdir -vp "${dname}" || die "Failed to mkdir ${dname}"
-	grub-mkconfig -o "${GRUB_CFG}" || die "Failed to generate GRUB config"
+	grub-mkconfig -o "${GRUB_CFG}" || eerror "grub-mkconfig failed"
 }
 
 main


### PR DESCRIPTION
In some situations, like when building binary packages in containers for consumption elsewhere, it is unwanted to attempt to perform bootloader configuration. In the worst case, this can cause the whole emerge run to fail if grub-mkconfig fails. This is obviously unwanted - it's not unexpected that grub-mkconfig fails in containers.

Signed-off-by: John Helmert III <ajak@gentoo.org>