### PR TITLE
installkernel: rm before mv to prevent error on hardlinks

### DIFF
--- a/installkernel
+++ b/installkernel
@@ -36,6 +36,8 @@ fi
 # Create backups of older versions before installing
 updatever () {
   if [ -f "$dir/$1-$ver$3" ] ; then
+    # If they are hardlinked together, mv will fail.
+    rm -f "$dir/$1-$ver$3.old"
     mv "$dir/$1-$ver$3" "$dir/$1-$ver$3.old"
   fi
 
@@ -53,10 +55,14 @@ updatever () {
             # Yup, we need to change
             ln -sf "$1-$ver$3.old" "$dir/$1$3.old"
         else
+            # If they are hardlinked together, mv will fail.
+            rm -f "$dir/$1$3.old"
             mv "$dir/$1$3" "$dir/$1$3.old"
         fi
         ln -sf "$1-$ver$3" "$dir/$1$3"
     else                        # No links
+        # If they are hardlinked together, mv will fail.
+        rm -f "$dir/$1$3.old"
         mv "$dir/$1$3" "$dir/$1$3.old"
         cat "$2" > "$dir/$1$3"
     fi


### PR DESCRIPTION
If the `.old` file is hard-linked to the file that is about to moved onto it, then the `mv` will fail:
```
$ mv vmlinuz-6.1.22-gentoo-dist vmlinuz-6.1.22-gentoo-dist.old
mv: 'vmlinuz-6.1.22-gentoo-dist' and 'vmlinuz-6.1.22-gentoo-dist.old' are the same file
```

We could conditionally test if it's hardlinked, but since we are moving anyway, just delete the `.old` file before the `mv`.

Testing for being hardlinked requires either non-POSIX `test $F1 -ef $F2` or GNU find `-samefile`, whereas the `rm ; mv` solution will work on POSIX shell.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>