### PR TITLE
Add ability to generate/install initrd or unified kernel image

### DIFF
--- a/hooks/50-dracut.install
+++ b/hooks/50-dracut.install
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# this file is installed by sys-kernel/installkernel-gentoo
+
+ver=${1}
+img=${2}
+initrd=${img%/*}/initrd
+
+# familiar helpers, we intentionally don't use Gentoo functions.sh
+die() {
+	echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
+	exit 1
+}
+
+einfo() {
+	echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
+}
+
+ewarn() {
+	echo -e " ${NOCOLOR-\e[1;33m*\e[0m }${*}" >&2
+}
+
+main() {
+	# re-define for subst to work
+	[[ -n ${NOCOLOR+yes} ]] && NOCOLOR=
+
+	# do nothing if somehow dracut is not installed
+	[[ -x $(command -v dracut) ]] || { ewarn "dracut is not installed" && exit 0 ; }
+
+	[[ ${EUID} -eq 0 ]] || die "Please run this script as root"
+
+	initramfs_gen_args=(
+		--force
+		--verbose
+		# if uefi=yes is used, dracut needs to locate the kernel image
+		--kernel-image "${img}"
+
+		# positional arguments
+		"${initrd}" "${ver}"
+		)
+
+	dracut "${initramfs_gen_args[@]}" || die "Failed to generate initramfs"
+
+	# if dracut is used in uefi=yes mode, initrd will actually
+	# be a combined kernel+initramfs UEFI executable.  we can easily
+	# recognize it by PE magic (vs cpio for a regular initramfs)
+	[[ -s ${initrd} ]] && read -n 2 magic < "${initrd}"
+	if [[ ${magic} == MZ ]]; then
+		einfo "Combined UEFI kernel+initramfs executable found"
+		# install the combined executable in place of kernel
+		uki=${initrd%/*}/uki.efi
+		mv "${initrd}" "${uki}" || die "Failed to rename initramfs"
+	fi
+}
+
+main

--- a/hooks/60-ukify.install
+++ b/hooks/60-ukify.install
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# this file is installed by sys-kernel/installkernel-gentoo
+
+ver=${1}
+img=${2}
+initrd=${img%/*}/initrd
+
+# familiar helpers, we intentionally don't use Gentoo functions.sh
+die() {
+	echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
+	exit 1
+}
+
+ewarn() {
+	echo -e " ${NOCOLOR-\e[1;33m*\e[0m }${*}" >&2
+}
+
+main() {
+	# re-define for subst to work
+	[[ -n ${NOCOLOR+yes} ]] && NOCOLOR=
+
+	# do nothing if somehow ukify is not installed
+	[[ -x $(command -v /usr/lib/systemd/ukify) ]] || { ewarn "ukify is not installed" && exit 0 ; }
+
+	[[ ${EUID} -eq 0 ]] || die "Please run this script as root"
+
+	ukify_gen_args=(
+		build
+		--linux="${img}"
+		--uname="${ver}"
+		--output="${initrd%/*}/uki.efi"
+		)
+
+	[[ -f "${initrd}" ]] && ukify_gen_args+=( --initrd="${initrd}" )
+
+	if [[ ${SECUREBOOT_SIGN_KEY} == pkcs11:* ]]; then
+		ukify_gen_args+=(
+			--secureboot-private-key="${SECUREBOOT_SIGN_KEY}"
+			--signing-engine=pkcs11
+		)
+	elif [[ -r ${SECUREBOOT_SIGN_KEY} ]]; then
+		ukify_gen_args+=(
+			--secureboot-private-key="${SECUREBOOT_SIGN_KEY}"
+		)
+	fi
+
+	if [[ -r ${SECUREBOOT_SIGN_CERT} ]]; then
+		ukify_gen_args+=(
+			--signtool=sbsign
+			--secureboot-certificate="${SECUREBOOT_SIGN_CERT}"
+		)
+	fi
+
+	/usr/lib/systemd/ukify "${ukify_gen_args[@]}" || die "Failed to generate UKI"
+}
+
+main

--- a/hooks/90-uki-copy.install
+++ b/hooks/90-uki-copy.install
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# this file is installed by sys-kernel/installkernel-gentoo
+
+ver=${1}
+img=${2}
+
+# familiar helpers, we intentionally don't use Gentoo functions.sh
+die() {
+	echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
+	exit 1
+}
+
+einfo() {
+	echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
+}
+
+main() {
+	# re-define for subst to work
+	[[ -n ${NOCOLOR+yes} ]] && NOCOLOR=
+
+	[[ ${EUID} -eq 0 ]] || die "Please run this script as root"
+
+	# Do nothing if the image we installed is not an EFI executable
+	[[ ${img} == *.efi ]] || exit 0
+
+	# When we have installed a UKI, copy it to the ESP. Some bootloaders
+	# can auto-discover installed efi executables in EFI/Linux. And having
+	# the UKI on the ESP is also required for EFI stub booting.
+	# Use the same potential ESP mounting locations as eclean-kernel.
+	for dir in /boot/EFI /boot/efi /boot /efi; do
+		if [[ -d "${dir}/EFI/Linux" ]]; then
+				local image_path="${dir}/EFI/Linux/gentoo-$(basename ${img#*-})"
+				einfo "Installing UKI to ${image_path}"
+				if [[ -f "${image_path}" ]]; then
+					mv "${image_path}" "${image_path%.efi}-old.efi" || die "Failed to move existing UKI"
+				fi
+				mv "${img}" "${image_path}" || die "Failed to install UKI"
+			break
+		else
+			continue
+		fi
+	done
+}
+
+main

--- a/installkernel
+++ b/installkernel
@@ -69,34 +69,53 @@ updatever () {
   fi
 }
 
+# If installing in the usual directory, run the same scripts that hook
+# into kernel package installation.  Also make sure the PATH includes
+# /usr/sbin and /sbin, just as dpkg would.
+if [ "${dir}" = "/boot" ]; then
+  PATH="${PATH}:/usr/sbin:/sbin" \
+    run-parts --verbose --exit-on-error --arg="${ver}" --arg="${img}" \
+    /etc/kernel/preinst.d
+fi
+
+# use the same input path as /usr/lib/kernel/install.d/50-dracut.install
+# and the same output path as dracut and genkernel-4 for best interop
+base_dir=$(dirname "${img}")
+initrd=${base_dir}/initrd
+uki=${base_dir}/uki.efi
+
 if [ "$(basename "$img")" = "vmlinux" ] ; then
   img_dest=vmlinux
 else
   img_dest=vmlinuz
 fi
-updatever $img_dest "$img"
-updatever System.map "$map"
 
-config=$(dirname "$map")
-config="${config}/.config"
-if [ -f "$config" ] ; then
-  updatever config "$config"
+# If we found a uki.efi, install it instead of kernel+initrd
+if [ -f ${uki} ]; then
+  suffix=.efi
+  updatever ${img_dest} "${uki}" ${suffix}
+else
+  suffix=
+  updatever ${img_dest} "${img}"
+  if [ -f "${initrd}" ] ; then
+    updatever initramfs "${initrd}" .img
+  fi
 fi
 
-# use the same input path as /usr/lib/kernel/install.d/50-dracut.install
-# and the same output path as dracut and genkernel-4 for best interop
-initrd=$(dirname "$img")
-initrd="${initrd}/initrd"
-if [ -f "$initrd" ] ; then
-  updatever initramfs "$initrd" .img
+updatever System.map "${map}"
+
+config=$(dirname "${map}")
+config="${config}/.config"
+if [ -f "${config}" ] ; then
+  updatever config "${config}"
 fi
 
 # If installing in the usual directory, run the same scripts that hook
 # into kernel package installation.  Also make sure the PATH includes
 # /usr/sbin and /sbin, just as dpkg would.
-if [ "$dir" = "/boot" ]; then
-  PATH="$PATH:/usr/sbin:/sbin" \
-    run-parts --verbose --exit-on-error --arg="$ver" --arg="$dir/$img_dest-$ver" \
+if [ "${dir}" = "/boot" ]; then
+  PATH="${PATH}:/usr/sbin:/sbin" \
+    run-parts --verbose --exit-on-error --arg="${ver}" --arg="${dir}/${img_dest}-${ver}${suffix}" \
     /etc/kernel/postinst.d
 fi
 

--- a/installkernel.8
+++ b/installkernel.8
@@ -11,7 +11,9 @@ tree.  It is called by the Linux kernel makefiles when
 .B make install
 is invoked there.
 .P
-The new kernel is installed into
+If the new kernel is an unified kernel image, it is installed into
+.IR {directory}/vmlinuz-{version}.efi .
+Otherwise, the new kernel is installed into
 .IR {directory}/vmlinuz-{version} .
 If a symbolic link
 .I {directory}/vmlinuz


### PR DESCRIPTION
This basically copies the code from dist-kernel-utils.eclass. Doing this here instead gives several advantages:
- Aligned behaviour with installkernel-systemd, which also generates an initrd or uki with dracut if it is installed.
- Aligned behaviour between manually compiled kernels (i.e. gentoo-sources) and dist-kernels (i.e. gentoo-kernel). With both it is now possible to automatically generate and install an initrd or uki if dracut is installed.
- Allows to significantly simplify dist-kernel-utils.eclass and kernel-install.eclass. Code paths that are now required only for installkernel-gentoo, but not for installkernel-systemd can be removed.

What is new is the ability to specify an alternate initrd generator, and the ability to pass additional arguments. Examples of useful arguments one might want to pass are: --verbose or --uefi/--no-uefi (to toggle between generating an initrd or uki).

CC @desultory @gentoo/dist-kernel @mgorny 
See-also: https://github.com/gentoo/gentoo/pull/33727