### PR TITLE
drop pointless dependency on external run-parts

### DIFF
--- a/installkernel
+++ b/installkernel
@@ -78,9 +78,16 @@ updatever() {
 # into kernel package installation.  Also make sure the PATH includes
 # /usr/sbin and /sbin, just as dpkg would.
 if [ "${dir}" = "/boot" ]; then
-	PATH="${PATH}:/usr/sbin:/sbin" \
-		run-parts --verbose --exit-on-error --arg="${ver}" --arg="${img}" \
-		/etc/kernel/preinst.d
+	(
+		export LC_ALL=C PATH="${PATH}:/usr/sbin:/sbin"
+
+
+		for x in /etc/kernel/preinst.d/*; do
+			[ -x "${x}" ] || continue
+			echo "running ${x} ${ver} ${img}"
+			"${x}" ${ver} "${img}"
+		done
+	)
 fi
 
 # use the same input path as /usr/lib/kernel/install.d/50-dracut.install


### PR DESCRIPTION
This external program belongs to debianutils and usage of it was likely synced from the original installkernel.

It has a couple utilities:
- it sorts files in a directory with LC_ALL=C
- it runs each of them in turn
- it can print the commands run

Here, it's used for sorting the scripts to run and running them all with the same arguments. But this functionality works fine directly from a shell with a simple loop, so the additional dependency honestly seems frivolous. In particular, this is one of only two reasons why a Gentoo system probably has run-parts installed, the other being openssl. (This is in contrast to Debian, where debianutils is part of the essential system set and provides a vastly greater number of programs than the ones Gentoo repackages.)

The installkernel program was already split out into its own program with distinctive utility for Gentoo. Adding *two* new package atoms to every Gentoo system seems a bit excessive for something so easily avoided, so avoid it.