### PR TITLE
installkernel: updatever: preserve file permissions

### DIFF
--- a/hooks/systemd/10-copy-prebuilt.install
+++ b/hooks/systemd/10-copy-prebuilt.install
@@ -19,20 +19,20 @@ UKI=${IMAGE_DIR}/uki.efi
 
 if [ -f "${INITRD}" ]; then
 	[ "${KERNEL_INSTALL_VERBOSE}" = "1" ] && echo "Copying prebuilt initramfs to staging area"
-	cp "${INITRD}" "${KERNEL_INSTALL_STAGING_AREA}/initrd" || exit 1
+	cp -a "${INITRD}" "${KERNEL_INSTALL_STAGING_AREA}/initrd" || exit 1
 fi
 
 if [ -f "${UKI}" ]; then
 	[ "${KERNEL_INSTALL_VERBOSE}" = "1" ] && echo "Copying prebuilt UKI to staging area"
-	cp "${UKI}" "${KERNEL_INSTALL_STAGING_AREA}/uki.efi" || exit 1
+	cp -a "${UKI}" "${KERNEL_INSTALL_STAGING_AREA}/uki.efi" || exit 1
 fi
 
 if [ -f "/boot/intel-uc.img" ]; then
 	[ "${KERNEL_INSTALL_VERBOSE}" = "1" ] && echo "Copying prebuilt Intel early microcode image to staging area"
-	cp "/boot/intel-uc.img" "${KERNEL_INSTALL_STAGING_AREA}/microcode-intel" || exit 1
+	cp -a "/boot/intel-uc.img" "${KERNEL_INSTALL_STAGING_AREA}/microcode-intel" || exit 1
 fi
 
 if [ -f "/boot/amd-uc.img" ]; then
 	[ "${KERNEL_INSTALL_VERBOSE}" = "1" ] && echo "Copying prebuilt AMD early microcode image to staging area"
-	cp "/boot/amd-uc.img" "${KERNEL_INSTALL_STAGING_AREA}/microcode-amd" || exit 1
+	cp -a "/boot/amd-uc.img" "${KERNEL_INSTALL_STAGING_AREA}/microcode-amd" || exit 1
 fi

--- a/hooks/systemd/90-compat.install
+++ b/hooks/systemd/90-compat.install
@@ -50,19 +50,19 @@ if [[ ${COMMAND} == add ]]; then
 	mkdir -p "${KERNEL_INSTALL_ROOT}" || exit 1
 
 	[[ ${KERNEL_INSTALL_VERBOSE} == 1 ]] && echo "Installing kernel image for ${KERNEL_VERSION}..."
-	cp "${KERNEL_IMAGE}" "${KERNEL_INSTALL_ROOT}/kernel-${KERNEL_VERSION}${SUFFIX}" || exit 1
+	cp -a "${KERNEL_IMAGE}" "${KERNEL_INSTALL_ROOT}/kernel-${KERNEL_VERSION}${SUFFIX}" || exit 1
 
 	INITRD="${KERNEL_INSTALL_STAGING_AREA}/initrd"
 	if [[ -f ${INITRD} ]]; then
 		[[ ${KERNEL_INSTALL_VERBOSE} == 1 ]] && echo "Installing initramfs image for ${KERNEL_VERSION}..."
-		cp "${INITRD}" "${KERNEL_INSTALL_ROOT}/initramfs-${KERNEL_VERSION}.img" || exit 1
+		cp -a "${INITRD}" "${KERNEL_INSTALL_ROOT}/initramfs-${KERNEL_VERSION}.img" || exit 1
 	fi
 
 	# Copy microcode to ESP so we can add it to the efistub entry
 	for CPU in intel amd; do
 		if [[ -f "${KERNEL_INSTALL_STAGING_AREA}/microcode-${CPU}" ]]; then
 			[[ ${KERNEL_INSTALL_VERBOSE} == 1 ]] && echo "Copying microcode for ${CPU} CPU..."
-			cp "${KERNEL_INSTALL_STAGING_AREA}/microcode-${CPU}" "${KERNEL_INSTALL_ROOT}/${CPU}-uc.img" || exit 1
+			cp -a "${KERNEL_INSTALL_STAGING_AREA}/microcode-${CPU}" "${KERNEL_INSTALL_ROOT}/${CPU}-uc.img" || exit 1
 		fi
 	done
 elif [[ ${COMMAND} == remove ]]; then

--- a/installkernel
+++ b/installkernel
@@ -145,7 +145,7 @@ updatever() {
 		mv "${dir}/${1}-${ver}${3}" "${dir}/${1}-${ver}${oldsuffix}"
 	fi
 
-	cat "${2}" >"${dir}/${1}-${ver}${3}"
+	cp -a "${2}" "${dir}/${1}-${ver}${3}"
 
 	# Update static version-less symlink/copy
 	if [ -f "${dir}/${1}${3}" ] || [ -L "${dir}/${1}${3}" ]; then
@@ -168,7 +168,7 @@ updatever() {
 			# If they are hardlinked together, mv will fail.
 			rm -f "${dir}/${1}${oldsuffix}"
 			mv "${dir}/${1}${3}" "${dir}/${1}${oldsuffix}"
-			cat "${2}" >"${dir}/${1}${3}"
+			cp -a "${2}" "${dir}/${1}${3}"
 		fi
 	fi
 }
@@ -234,10 +234,10 @@ main() {
 						suffix=.efi
 						# backwards compatibility
 						if [ -f "/boot/intel-uc.img" ]; then
-							cp "/boot/intel-uc.img" "${dir}/intel-uc.img"
+							cp -a "/boot/intel-uc.img" "${dir}/intel-uc.img"
 						fi
 						if [ -f "/boot/amd-uc.img" ]; then
-							cp "/boot/amd-uc.img" "${dir}/amd-uc.img"
+							cp -a "/boot/amd-uc.img" "${dir}/amd-uc.img"
 						fi
 					else
 						continue
@@ -263,10 +263,10 @@ main() {
 
 	# Copy prebuilt initrd, uki.efi at kernel location
 	if [ -f "${prebuilt_initrd}" ]; then
-		cp "${prebuilt_initrd}" "${initrd}"
+		cp -a "${prebuilt_initrd}" "${initrd}"
 	fi
 	if [ -f "${prebuilt_uki}" ]; then
-		cp "${prebuilt_uki}" "${uki}"
+		cp -a "${prebuilt_uki}" "${uki}"
 	fi
 
 	# If installing in the usual directory, run the same scripts that hook


### PR DESCRIPTION
This is especially important for initramfs where it may contain sensitive keys in plaintext (such as ZFS decryption key).

dracut by default produces initrd with umask 077. With the current cat piped to file approach we'd lose file permissions.