### PR TITLE
91-sbctl.install: add install hook for sbctl

### DIFF
--- a/hooks/91-sbctl.install
+++ b/hooks/91-sbctl.install
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#shellcheck disable=SC2034
+
+# Copyright 2024 Gentoo Authors
+# This script is installed by sys-kernel/installkernel, it is executed by the
+# traditional installkernel, NOT by systemd's kernel-install. I.e. this plugin
+# is run when the systemd USE flag is disabled or SYSTEMD_KERNEL_INSTALL=0 is
+# set in the environment.
+
+ver=${1}
+img=${2}
+
+# familiar helpers, we intentionally don't use Gentoo functions.sh
+die() {
+	echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
+	exit 1
+}
+
+einfo() {
+	[[ ${INSTALLKERNEL_VERBOSE} == 1 ]] || return 0
+	echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}"
+}
+
+
+main() {
+	# re-define for subst to work
+	[[ -n ${NOCOLOR+yes} ]] && NOCOLOR=
+
+	# do nothing if secureboot key directory doesn't exist
+	if ! [ "$(sbctl setup --print-state --json | awk '/installed/ { gsub(/,$/,"",$2); print $2 }')" = "true" ]; then
+		einfo "Secureboot key directory doesn't exist, not signing!"
+		exit 0
+	fi
+
+	[[ ${EUID} -eq 0 ]] || die "Please run this script as root"
+
+	einfo "sbctl: Signing kernel $img"
+	sbctl sign -s $img 1> /dev/null
+}
+
+main

--- a/installkernel-9999.ebuild
+++ b/installkernel-9999.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}/${PN}-gentoo-${PV}"
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="dracut efistub grub refind systemd systemd-boot ugrd uki ukify"
+IUSE="dracut efistub grub refind sbctl systemd systemd-boot ugrd uki ukify"
 REQUIRED_USE="
 	systemd-boot? ( systemd )
 	ukify? ( uki )
@@ -69,6 +69,9 @@ RDEPEND="
 			sys-apps/systemd-utils[boot(-),ukify(-)]
 		)
 	)
+	sbctl? (
+		app-crypt/sbctl
+	)
 	ugrd? ( >=sys-kernel/ugrd-1.31.2 )
 	!=sys-apps/systemd-255.2-r1
 	!=sys-apps/systemd-255.2-r0
@@ -102,6 +105,7 @@ src_install() {
 	use grub && doexe hooks/91-grub-mkconfig.install
 	use efistub && doexe hooks/95-efistub-uefi-mkconfig.install
 	use refind && doexe hooks/95-refind-copy-icon.install
+	use sbctl && ! use systemd && doexe hooks/91-sbctl.install
 
 	exeinto /usr/lib/kernel/install.d
 	doexe hooks/systemd/00-00machineid-directory.install


### PR DESCRIPTION
sbctl has a [post-install script](https://github.com/Foxboron/sbctl/blob/master/contrib/kernel-install/91-sbctl.install) for kernel-install, not for installkernel. To sign the the kernel with sbctl, I added the script and updated the install function accordingly. I also introduced a new USE flag (`sbctl`), which indicates to use sbctl for signing. I didn't want to add the hook to `app-crypt/sbctl`, since I should've removed some Gentoo/Installkernel-specific display stuff (e.g. the colored stars, formatted output) then. I'd love to see some feedback and get it upstream asap.