### PR TITLE
installkernel-9999.ebuild: fix as an live ebuild

### DIFF
--- a/installkernel-9999.ebuild
+++ b/installkernel-9999.ebuild
@@ -3,16 +3,14 @@
 
 EAPI=8
 
-inherit eapi9-ver linux-info
+inherit eapi9-ver git-r3 linux-info
 
 DESCRIPTION="Gentoo fork of installkernel script from debianutils"
 HOMEPAGE="
 	https://github.com/projg2/installkernel-gentoo
 	https://wiki.gentoo.org/wiki/Installkernel
 "
-SRC_URI="https://github.com/projg2/installkernel-gentoo/archive/v${PV}.tar.gz
-	-> ${P}.tar.gz"
-S="${WORKDIR}/${PN}-gentoo-${PV}"
+EGIT_REPO_URI="https://github.com/projg2/installkernel-gentoo.git"
 
 LICENSE="GPL-2+"
 SLOT="0"


### PR DESCRIPTION
the 9999 version is broken if use version tag