### PR TITLE
installkernel: Support drop-in files for install.conf

### DIFF
--- a/installkernel
+++ b/installkernel
@@ -515,39 +515,39 @@ if [ ${has_read_conf} -ne 1 ]; then
 	exit 1
 fi
 
-	if [ -n "${layout}" ]; then
-		if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
-			echo "Read configuration layout=${layout}"
-		fi
-		if [ -z "${INSTALLKERNEL_LAYOUT}" ]; then
-			INSTALLKERNEL_LAYOUT="${layout}"
-		fi
-	else
-		echo "No layout= configured by ${install_conf}"
-		exit 1
+if [ -n "${layout}" ]; then
+	if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
+		echo "Read configuration layout=${layout}"
 	fi
-	if [ -n "${initrd_generator}" ]; then
-		if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
-			echo "Read configuration initrd_generator=${initrd_generator}"
-		fi
-		if [ -z "${INSTALLKERNEL_INITRD_GENERATOR}" ]; then
-			INSTALLKERNEL_INITRD_GENERATOR="${initrd_generator}"
-		fi
-	else
-		echo "No initrd_generator= configured by ${install_conf}"
-		exit 1
+	if [ -z "${INSTALLKERNEL_LAYOUT}" ]; then
+		INSTALLKERNEL_LAYOUT="${layout}"
 	fi
-	if [ -n "${uki_generator}" ]; then
-		if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
-			echo "Read configuration uki_generator=${uki_generator}"
-		fi
-		if [ -z "${INSTALLKERNEL_UKI_GENERATOR}" ]; then
-			INSTALLKERNEL_UKI_GENERATOR="${uki_generator}"
-		fi
-	else
-		echo "No uki_generator= configured by ${install_conf}"
-		exit 1
+else
+	echo "No layout= configured by ${install_conf}"
+	exit 1
+fi
+if [ -n "${initrd_generator}" ]; then
+	if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
+		echo "Read configuration initrd_generator=${initrd_generator}"
 	fi
+	if [ -z "${INSTALLKERNEL_INITRD_GENERATOR}" ]; then
+		INSTALLKERNEL_INITRD_GENERATOR="${initrd_generator}"
+	fi
+else
+	echo "No initrd_generator= configured by ${install_conf}"
+	exit 1
+fi
+if [ -n "${uki_generator}" ]; then
+	if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
+		echo "Read configuration uki_generator=${uki_generator}"
+	fi
+	if [ -z "${INSTALLKERNEL_UKI_GENERATOR}" ]; then
+		INSTALLKERNEL_UKI_GENERATOR="${uki_generator}"
+	fi
+else
+	echo "No uki_generator= configured by ${install_conf}"
+	exit 1
+fi
 
 export INSTALLKERNEL_LAYOUT
 export INSTALLKERNEL_INITRD_GENERATOR

--- a/installkernel
+++ b/installkernel
@@ -134,6 +134,22 @@ dropindirs_sort() {
     done
 }
 
+# Used to find drop-in files for install.conf
+dropinconfs_sort() {
+    for d; do
+        for i in "${d}/"*.conf; do
+            [ -e "${i}" ] && echo "${i##*/}"
+        done
+    done | sort -Vu | while read -r f; do
+        for d; do
+			if [ -e "${d}/${f}" ]; then
+				echo "${d}/${f}"
+				continue 2
+			fi
+        done
+    done
+}
+
 # Create backups of older versions before installing
 updatever() {
 	oldsuffix="${3}.old"
@@ -440,7 +456,10 @@ main() {
 	return 0
 }
 
-# Find and read the install.conf
+# Read configuration
+has_read_conf=0
+
+# First find and read the install.conf
 if [ -n "${INSTALLKERNEL_CONF_ROOT}" ]; then
 	install_conf="${INSTALLKERNEL_CONF_ROOT}/install.conf"
 elif [ -f /etc/kernel/install.conf ]; then
@@ -461,10 +480,44 @@ if [ -f "${install_conf}" ]; then
 	fi
 	# shellcheck source=/dev/null
 	. "${install_conf}"
+	has_read_conf=1
+else
+	if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
+		echo "No install.conf found at ${install_conf}"
+	fi
+fi
+
+# Read drop-in files for install.conf
+if [ -n "${INSTALLKERNEL_CONF_ROOT}" ]; then
+	# Don't read drop-ins in other directories;
+	# this behavior is consistent with kernel-install
+	dropins="$(dropinconfs_sort "${INSTALLKERNEL_CONF_ROOT}/install.conf.d")"
+else
+	dropins="$(
+		dropinconfs_sort \
+		"/etc/kernel/install.conf.d" \
+		"/run/kernel/install.conf.d" \
+		"/usr/local/lib/kernel/install.conf.d" \
+		"/usr/lib/kernel/install.conf.d"
+	)"
+fi
+for dropin in ${dropins}; do
+	if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
+		echo "Reading drop-in file ${dropin}..."
+	fi
+	# shellcheck source=/dev/null
+	. "${dropin}"
+	has_read_conf=1
+done
+
+if [ ${has_read_conf} -ne 1 ]; then
+	echo "No install.conf found at ${install_conf}, and no drop-in file found"
+	exit 1
+fi
 
 	if [ -n "${layout}" ]; then
 		if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
-			echo "${install_conf} configures layout=${layout}"
+			echo "Read configuration layout=${layout}"
 		fi
 		if [ -z "${INSTALLKERNEL_LAYOUT}" ]; then
 			INSTALLKERNEL_LAYOUT="${layout}"
@@ -475,7 +528,7 @@ if [ -f "${install_conf}" ]; then
 	fi
 	if [ -n "${initrd_generator}" ]; then
 		if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
-			echo "${install_conf} configures initrd_generator=${initrd_generator}"
+			echo "Read configuration initrd_generator=${initrd_generator}"
 		fi
 		if [ -z "${INSTALLKERNEL_INITRD_GENERATOR}" ]; then
 			INSTALLKERNEL_INITRD_GENERATOR="${initrd_generator}"
@@ -486,7 +539,7 @@ if [ -f "${install_conf}" ]; then
 	fi
 	if [ -n "${uki_generator}" ]; then
 		if [ "${INSTALLKERNEL_VERBOSE}" -gt 0 ]; then
-			echo "${install_conf} configures uki_generator=${uki_generator}"
+			echo "Read configuration uki_generator=${uki_generator}"
 		fi
 		if [ -z "${INSTALLKERNEL_UKI_GENERATOR}" ]; then
 			INSTALLKERNEL_UKI_GENERATOR="${uki_generator}"
@@ -495,10 +548,6 @@ if [ -f "${install_conf}" ]; then
 		echo "No uki_generator= configured by ${install_conf}"
 		exit 1
 	fi
-else
-	echo "No install.conf found at ${install_conf}"
-	exit 1
-fi
 
 export INSTALLKERNEL_LAYOUT
 export INSTALLKERNEL_INITRD_GENERATOR

--- a/installkernel.8
+++ b/installkernel.8
@@ -138,3 +138,21 @@ INSTALLKERNEL_UKI_GENERATOR
 respectively. If the environment variable
 .B INSTALLKERNEL_CONF_ROOT
 is set, then the install.conf at this location is used instead.
+.P
+Drop-in files may also be used to partially override the settings. The syntax
+for drop-in files is the same as that for install.conf. However, a drop-in file
+need not define all these settings; it just needs to define settings that
+override install.conf. Each drop-in file should have filename suffix ".conf".
+.P
+Drop-in files should be placed in one of these directories
+.IR /etc/kernel/install.conf.d/
+.IR /run/kernel/install.conf.d/
+.IR /usr/local/lib/kernel/install.conf.d/
+.IR /usr/lib/kernel/install.conf.d/.
+Drop-in files in directories listed earlier override files with the same name
+in directories listed later. Multiple drop-in files with different names are
+applied in lexicographic order, regardless of which directory they reside in.
+If the environment variable
+.B INSTALLKERNEL_CONF_ROOT
+is set, then the install.conf.d directory at this location is used instead, and
+no other directory is used.


### PR DESCRIPTION
systemd's `kernel-install` supports drop-in files for `install.conf`: if users want to override just some settings in `/usr/lib/kernel/install.conf`, they can create a drop-in file under directory `/etc/kernel/install.conf.d/` and define just those settings in it.  A drop-in file need not define all settings in the original `install.conf` because it is overlaid atop `install.conf` rather than completely replace `install.conf`.  I discovered this recently while reading the `kernel-install(8)` manual page and added [instructions](https://wiki.gentoo.org/wiki/Installkernel#:~:text=mkdir%20%2Fetc%2Fkernel%2Finstall%2Econf%2Ed) to create drop-in files to Gentoo Wiki's page for `installkernel`.

Since the Wiki page has a statement

> Gentoo strives to ensure a rough feature parity between both implementations.

it would be great if Debian's traditional `installkernel` script also supports `install.conf` drop-in files.  This pull request adds such support to the script itself and relevant documentation to the `installkernel.8` manual page.

To make it easier to review the changes, I split changes to the `installkernel` script into two commits:
- `installkernel: Support drop-in files for install.conf`: All functional changes are in this commit.
- `installkernel: Fix code indentation`: This commit only entails code reformatting.

The split makes the first commit's diff easier to read and understand.  That said, feel free to amend the second commit into the first one after review is complete, or just let me know and I can amend it.